### PR TITLE
Feature/154 Disabled inputs when the box is closed and changed design when the bo…

### DIFF
--- a/js/moving-details.js
+++ b/js/moving-details.js
@@ -660,11 +660,17 @@ const buildBoxesList = (boxes) => {
     const boxImage = document.createElement('div');
     boxImage.classList.add('box__image');
     const boxStatusIcon = document.createElement('span');
+    
     if (box.status) {
       boxStatusIcon.className = `fak fa-close-box`;
+      //Adding color change
+      boxContainer.classList.add("closed");
     } else {
       boxStatusIcon.className = `fak fa-open-box`;
+      //Adding color change
+      boxContainer.classList.remove("closed");
     }
+
     const sizeWrapper = document.createElement('p');
     const sizeLabel = document.createElement('span');
     const sizeText = document.createTextNode(`${box.boxSize}`);
@@ -683,10 +689,10 @@ const buildBoxesList = (boxes) => {
     boxMetadata.classList.add('box__metadata');
     boxMetadata.innerHTML = `<a onclick="sendItemId(this)" href="box-content.html"><p>${
       box.name
-    }</p></a>
-
+    }</p></a>  
                              <p>${box.label}</p>
-                             <p>${box.fragile ? 'Fragile' : ''}</p>`;
+                             <p>${box.fragile ? 'Fragile' : ''}</p>
+                             <p>${box.status ? 'Close' : ''}</p>`;
 
     const boxActions = document.createElement('div');
     boxActions.classList.add('box__actions');
@@ -788,6 +794,8 @@ editBoxModal.addEventListener('shown.bs.modal', async () => {
   const boxSizesBtns = document.querySelectorAll(
     '.editBoxContent__boxDimensionsButtons button'
   );
+  const msgWhenClose = document.getElementById('msgWhenClose');
+
   try {
     const movingId = window.sessionStorage.getItem('movingId');
     const boxSelectedId = document.getElementById('boxSelectedId').value;
@@ -822,11 +830,90 @@ editBoxModal.addEventListener('shown.bs.modal', async () => {
         boxSize.classList.remove('editBoxContent__left_button_selected');
       }
     });
+
+    // Disable input area in edit box mode and change clore of box page, when the box is closed and when it's rendered
+    if(idBoxCloseCheck.checked) {
+      idEditBoxNameInput.disabled = true; 
+      idEditBoxDescriptionInput.disabled = true;
+      idEditBoxLabelList.disabled = true;
+
+      for(i=0; i<boxSizesBtns.length; i++){
+        boxSizesBtns[i].disabled = true;
+      }
+
+      BoxWeightInput.disabled = true;
+      idBoxFragileCheck.disabled = true;
+
+      msgWhenClose.style.opacity = 1;
+      
+    } else {
+      idEditBoxNameInput.disabled = false; 
+      idEditBoxDescriptionInput.disabled = false;
+      idEditBoxLabelList.disabled = false;
+
+      for(i=0; i<boxSizesBtns.length; i++){
+        boxSizesBtns[i].disabled = false;
+      }
+
+      BoxWeightInput.disabled = false;
+      idBoxFragileCheck.disabled = false;
+
+      msgWhenClose.style.opacity = 0;
+    }
+
   } catch (err) {
     console.log('Error getting the box: ', err);
   }
 });
 
+
+// When Switched box close/Open
+const idBoxCloseCheck = document.getElementById('idBoxCloseCheck');
+
+idBoxCloseCheck.addEventListener('change', () => {
+
+  // Disable input area when the box is closed in edit modal
+  const idEditBoxNameInput = document.getElementById('idEditBoxNameInput');
+  const idEditBoxDescriptionInput = document.getElementById(
+    'idEditBoxDescriptionInput'
+  );
+  const idEditBoxLabelList = document.getElementById('idEditBoxLabelList');
+  const BoxWeightInput = document.getElementById('BoxWeightInput');
+  const idBoxFragileCheck = document.getElementById('idBoxFragileCheck');
+  const boxSizesBtns = document.querySelectorAll(
+    '.editBoxContent__boxDimensionsButtons button'
+  );
+  const msgWhenClose = document.getElementById('msgWhenClose');
+ 
+  if(idBoxCloseCheck.checked) {
+    idEditBoxNameInput.disabled = true; 
+    idEditBoxDescriptionInput.disabled = true;
+    idEditBoxLabelList.disabled = true;
+
+    for(i=0; i<boxSizesBtns.length; i++){
+      boxSizesBtns[i].disabled = true;
+    }
+
+    BoxWeightInput.disabled = true;
+    idBoxFragileCheck.disabled = true;
+
+    msgWhenClose.style.opacity = 1;
+    
+  } else {
+    idEditBoxNameInput.disabled = false; 
+    idEditBoxDescriptionInput.disabled = false;
+    idEditBoxLabelList.disabled = false;
+
+    for(i=0; i<boxSizesBtns.length; i++){
+      boxSizesBtns[i].disabled = false;
+    }
+
+    BoxWeightInput.disabled = false;
+    idBoxFragileCheck.disabled = false;
+
+    msgWhenClose.style.opacity = 0;
+  }
+})
 /**
  * Edit a box according to a moving id
  */

--- a/pages/moving-details.html
+++ b/pages/moving-details.html
@@ -644,6 +644,7 @@
                       To enable the PDF</label
                     >
                   </div>
+                  <p id="msgWhenClose">To edit, please open the box </p>
                 </div>
               </div>
             </div>

--- a/sass/partials/moving-details/_moving-details.scss
+++ b/sass/partials/moving-details/_moving-details.scss
@@ -109,6 +109,7 @@
             font-size: 1.2rem;
           }
 
+          &:nth-child(3),
           &:last-child {
             font-size: 0.9rem;
             text-transform: uppercase;
@@ -156,6 +157,18 @@
             border-bottom: 2px solid $accent-color;
           }
         }
+      }
+    }
+
+    .box.closed {
+      background-color: $mid-grey;
+
+      .box__metadata {
+        background-color: $mid-grey;
+      }
+
+      .box__actions {
+        background-color: $mid-grey;
       }
     }
   }

--- a/sass/partials/moving-details/_new-box.scss
+++ b/sass/partials/moving-details/_new-box.scss
@@ -161,3 +161,12 @@
     border: 1px solid $field-alert-color;
   }
 }
+
+// Message of "To edit, please open the box" in edit box modal  
+#editBoxModal .editBoxContent__editBoxSwitch {
+  #msgWhenClose{
+    color: $field-alert-color;
+    margin-top: 1rem 0.5rem;
+    opacity: 0;
+  }
+}

--- a/sass/partials/variables/_colors.scss
+++ b/sass/partials/variables/_colors.scss
@@ -20,6 +20,7 @@ $desktop-left-bg-color: #044468;
 $primary-color: #044468;
 $accent-color: #f99d14;
 $grey: #5f5e5e;
+$mid-grey: #979797;
 $green: #299c00;
 $MovingTitle-desktop-color: white;
 $paragraphCopyright-color: white;


### PR DESCRIPTION
Hi Jose/Sam!

Please kindly check the below.

- Disabled the inputs in edit box modal (I put codes for when it's loading and codes for immediate change when the user switched)
- Changed design of box card when it's closed. Design seems not yet done when I checked figma, I just put simple ones for now (bg-color to grey, add "Closed" in the card). I will create another issue card when the actual design is available. Close #156 

The below is just my self notes for the design change later. Please disregard.
Thank you.


https://user-images.githubusercontent.com/84117994/127149717-bdd4e730-4f09-4d42-af72-577f2ab0813f.png
https://user-images.githubusercontent.com/84117994/127149728-166ca692-8d81-4659-8991-cc983ef2e1de.png
https://user-images.githubusercontent.com/84117994/127149735-52369f5c-6393-4f2b-808a-e7b61f6eafc8.png
https://user-images.githubusercontent.com/84117994/127149747-f316d1c5-954d-4ead-b0a1-29151475d734.png
https://user-images.githubusercontent.com/84117994/127149758-935e7e2b-0c9b-401c-b90f-68a0c3f4f3bb.png