### PR TITLE
Feature/202 - Fix bug in add/edit item flow

### DIFF
--- a/js/box-content.js
+++ b/js/box-content.js
@@ -24,6 +24,7 @@ const changeAddItemModalTitle = (title) => {
   const boxLabelsModalLabel = document.getElementById('boxLabelsModalLabel');
   boxLabelsModalLabel.innerHTML = title;
   cleanInputs();
+  if (title !== 'Update item') cleanHiddenidInput();
 };
 
 /********************************/


### PR DESCRIPTION
- Fix bug when cancel edit item modal form and the add new item, it was updating the box that was cancel when editing instead of creating. Now it's fixed.

@samvvw Could you please help me testing that part again and let me know the results? 

Thanks!