### PR TITLE
Fixed box-shadow problem in IOS

### DIFF
--- a/sass/partials/_elements.scss
+++ b/sass/partials/_elements.scss
@@ -469,3 +469,9 @@
   background-color: #aaa4;
   margin: 1em;
 }
+
+//To fix box-shadow issue in IOS
+input:not([type="date"]){
+  -webkit-appearance: none; 
+  appearance: none;
+}


### PR DESCRIPTION
Hi Sam!

I have tried to fix the issue which the box-shadow of input disappear in IOS. Close #236 
I tested with chrome and safari in iphone and ipad, looks okay. 
I just avoided input [type="date"], as it was better with the browser default. 
Please kindly check/test and approve, as you use iphone as well. 
Thank you.

Hi Jose, 
Thank you for your help, too!

Meg 